### PR TITLE
Include base and user API controllers

### DIFF
--- a/lib/voyage/app_builder.rb
+++ b/lib/voyage/app_builder.rb
@@ -555,6 +555,26 @@ module Suspenders
       template '../templates/specs/support/request_spec_helper.rb', 'spec/support/request_spec_helper.rb', force: true
     end
 
+    def add_api_foundation
+      # Create /app/api/base_api_controller.rb
+      template '../templates/api_base_controller.rb', 'app/controllers/api/base_api_controller.rb', force: true
+
+      # Create /app/api/v1/users_controller.rb
+      template '../templates/api_users_controller.rb', 'app/controllers/api/v1/users_controller.rb', force: true
+
+      # Update routes to include namespaced API
+      inject_into_file 'config/routes.rb', before: /^end/ do <<-RUBY.gsub(/^ {6}/, '')
+
+        # API-specific routes
+        namespace 'api' do
+          namespace 'v1' do
+            resources :users, except: [:new, :edit]
+          end
+        end
+        RUBY
+      end
+    end
+
     def customize_application_js
       template '../templates/application.js', 'app/assets/javascripts/application.js', force: true
 

--- a/lib/voyage/generators/app_generator.rb
+++ b/lib/voyage/generators/app_generator.rb
@@ -48,6 +48,7 @@ module Suspenders
 
 
       # Do these last
+      invoke :add_api_foundation
       invoke :rake_db_setup
       invoke :configure_rvm_prepend_bin_to_path
       invoke :run_rubocop_auto_correct
@@ -149,6 +150,10 @@ module Suspenders
 
     def spin_up_webpacker
       build :spin_up_webpacker
+    end
+
+    def add_api_foundation
+      build :add_api_foundation
     end
 
     def rake_db_setup

--- a/lib/voyage/templates/api_base_controller.rb
+++ b/lib/voyage/templates/api_base_controller.rb
@@ -1,0 +1,38 @@
+module Api
+  class BaseApiController < ApplicationController
+    # Disable CSRF protection for API calls
+    protect_from_forgery with: :null_session
+
+    # Disable cookie usage
+    before_action :destroy_session
+
+    # Handle objects that aren't found
+    rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+    def respond_with_errors(object)
+      serialized_errors = object.errors.messages.map do |field, errors|
+        errors.map do |error_message|
+          {
+            status: 422,
+            source: { pointer: "/data/attributes/#{field}" },
+            detail: error_message,
+          }
+        end
+      end.flatten
+
+      render json: { errors: serialized_errors },
+             status: :unprocessable_entity
+    end
+
+    private
+
+    def destroy_session
+      request.session_options[:skip] = true
+    end
+
+    def not_found
+      render json: { errors: 'Not found' },
+             status: 404
+    end
+  end
+end

--- a/lib/voyage/templates/api_users_controller.rb
+++ b/lib/voyage/templates/api_users_controller.rb
@@ -1,0 +1,56 @@
+module Api
+  module V1
+    class UsersController < BaseApiController
+      authorize_resource
+      respond_to :json
+
+      def index
+        respond_with(User.all)
+      end
+
+      def show
+        @user = User.find(params[:id])
+        respond_with(@user)
+      end
+
+      def create
+        @user = User.new(user_params)
+
+        if @user.save
+          respond_with @user do |format|
+            format.json { render json: @user, status: :created }
+          end
+        else
+          respond_with_errors(@user)
+        end
+      end
+
+      def update
+        @user = User.find(params[:id])
+
+        if @user.update_attributes(user_params)
+          respond_with(@user)
+        else
+          respond_with_errors(@user)
+        end
+      end
+
+      def destroy
+        user = User.find(params[:id])
+
+        if user.destroy
+          render json: {}, status: 204
+        else
+          render json: {}, status: 500
+        end
+      end
+
+      private
+
+      def user_params
+        params.require(:user).permit(:first_name, :last_name, :email,
+                                     :password, :password_confirmation)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This backports the basic API setup being used for the beginnings of Hypremium. I've moved the API-specific overrides into the BaseApiController now, so no changes should be necessary to ApplicationController.

Something we may want to consider: should we version the base controller for the API as well (i.e. Api::V1::BaseApiController, Api::V2::BaseApiController)? Right now if any logic changes within the core base controller it will effect all versions of the API's endpoints. This is nice for making bug fixes across the board, but we have to be careful to only make behavior-dependent changes in the actual API controller subclasses.