### PR TITLE
Feature/switch to sidekiq

### DIFF
--- a/lib/voyage/app_builder.rb
+++ b/lib/voyage/app_builder.rb
@@ -1,5 +1,7 @@
 module Suspenders
   class AppBuilder < Rails::AppBuilder
+    include Suspenders::Actions
+
     def agree?(prompt)
       puts prompt
       response = STDIN.gets.chomp
@@ -742,6 +744,20 @@ module Suspenders
       run 'chmod +x $rvm_path/hooks/after_cd_bundler'
 
       run 'mkdir -p .git/safe'
+    end
+
+    def configure_sidekiq
+      template '../templates/Procfile', 'Procfile', force: true
+      template '../templates/config_initializers_sidekiq.rb.erb', 'config/initializers/sidekiq.rb', force: true
+      template '../templates/config_sidekiq.yml', 'config/sidekiq.yml', force: true
+
+      sidekiq_config = <<-EOD
+# Use Sidekiq for background job processing
+  config.active_job.queue_adapter = :sidekiq
+      EOD
+
+      configure_environment('development', sidekiq_config)
+      configure_environment('production', sidekiq_config)
     end
 
     def run_rubocop_auto_correct

--- a/lib/voyage/generators/app_generator.rb
+++ b/lib/voyage/generators/app_generator.rb
@@ -49,6 +49,7 @@ module Suspenders
       invoke :add_api_foundation
       invoke :rake_db_setup
       invoke :configure_rvm_prepend_bin_to_path
+      invoke :configure_sidekiq
       invoke :run_rubocop_auto_correct
       invoke :copy_env_to_example
       invoke :add_to_gitignore
@@ -152,6 +153,10 @@ module Suspenders
 
     def configure_rvm_prepend_bin_to_path
       build :configure_rvm_prepend_bin_to_path
+    end
+
+    def configure_sidekiq
+      build :configure_sidekiq
     end
 
     def setup_spring

--- a/lib/voyage/templates/Gemfile.erb
+++ b/lib/voyage/templates/Gemfile.erb
@@ -5,7 +5,6 @@ ruby "<%= Voyage::RUBY_VERSION %>"
 #ruby-gemset
 
 gem "autoprefixer-rails"
-<%# gem "delayed_job_active_record" %>
 gem "flutie"
 gem "honeybadger"
 gem "jquery-rails"
@@ -15,7 +14,9 @@ gem "pg"
 gem "rack-canonical-host"
 gem "rails", "<%= Voyage::RAILS_VERSION %>"
 gem "recipient_interceptor"
+gem "redis-namespace"
 gem "sass-rails", "~> 5.0"
+gem "sidekiq"
 gem "simple_form"
 gem "skylight"
 gem "sprockets", ">= 3.0.0"

--- a/lib/voyage/templates/Procfile
+++ b/lib/voyage/templates/Procfile
@@ -1,0 +1,3 @@
+web: bundle exec rails server
+worker: bundle exec sidekiq
+release: bundle exec rake db:migrate

--- a/lib/voyage/templates/README.md.erb
+++ b/lib/voyage/templates/README.md.erb
@@ -35,6 +35,7 @@ Model & spec files are automatically annotated each time `rake db:migrate` is ru
 # Set Heroku Config Vars
 
     heroku config:set FORCE_SEED=1
+    heroku config:set REDIS_URL=''
     heroku config:set SEGMENT_ANALYTICS_RUBY_KEY=''
     heroku config:set SMTP_ADDRESS=''
     heroku config:set SMTP_DOMAIN=''

--- a/lib/voyage/templates/README.md.erb
+++ b/lib/voyage/templates/README.md.erb
@@ -7,7 +7,7 @@ with the necessary dependencies to run and test this app:
 
     % ./bin/setup
 
-It assumes you have a machine equipped with Ruby, Postgres, etc.
+It assumes you have a machine equipped with Ruby, Postgres, Redis, etc.
 
 ## Seeded Data
 

--- a/lib/voyage/templates/config_initializers_sidekiq.rb.erb
+++ b/lib/voyage/templates/config_initializers_sidekiq.rb.erb
@@ -1,0 +1,14 @@
+redis_namespace = '<%= app_name %>'
+sidekiq_config = if ENV['REDIS_URL']
+                   { url: ENV['REDIS_URL'], namespace: redis_namespace }
+                 else
+                   { namespace: redis_namespace }
+                 end
+
+Sidekiq.configure_server do |config|
+  config.redis = sidekiq_config
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = sidekiq_config
+end

--- a/lib/voyage/templates/config_sidekiq.yml
+++ b/lib/voyage/templates/config_sidekiq.yml
@@ -1,0 +1,2 @@
+:queues:
+  - default


### PR DESCRIPTION
Configure our Voyage generator to use sidekiq for background job processing and as the ActiveJob backend (to handle mailers and any other ActiveJob interfaces).

This requires a Redis install, which I've added to the generated README as well.

This completes issue #22