### PR TITLE
Use letter_opener for mail delivery in development

### DIFF
--- a/lib/voyage/app_builder.rb
+++ b/lib/voyage/app_builder.rb
@@ -820,6 +820,12 @@ RUBY
       configure_environment('production', sidekiq_config)
     end
 
+    def configure_letter_opener
+      gsub_file 'config/environments/development.rb',
+        'config.action_mailer.delivery_method = :file',
+        'config.action_mailer.delivery_method = :letter_opener'
+    end
+
     def run_rubocop_auto_correct
       run 'rubocop --auto-correct'
     end

--- a/lib/voyage/generators/app_generator.rb
+++ b/lib/voyage/generators/app_generator.rb
@@ -51,6 +51,7 @@ module Suspenders
       invoke :rake_db_setup
       invoke :configure_rvm_prepend_bin_to_path
       invoke :configure_sidekiq
+      invoke :configure_letter_opener
       invoke :run_rubocop_auto_correct
       invoke :copy_env_to_example
       invoke :add_to_gitignore
@@ -162,6 +163,10 @@ module Suspenders
 
     def configure_sidekiq
       build :configure_sidekiq
+    end
+
+    def configure_letter_opener
+      build :configure_letter_opener
     end
 
     def setup_spring


### PR DESCRIPTION
We already have the `letter_opener` gem in our development and test groups, but we weren't actually using it in development by default. This PR switches the configuration for development to take advantage of it.

For issue #16 