### PR TITLE
Chore/auto generate erd

### DIFF
--- a/lib/voyage/app_builder.rb
+++ b/lib/voyage/app_builder.rb
@@ -830,6 +830,12 @@ RUBY
         'config.action_mailer.delivery_method = :letter_opener'
     end
 
+    def configure_erd
+      bundle_command 'exec rails generate erd:install'
+
+      template '../templates/erdconfig.erb', '.erdconfig', force: true
+    end
+
     def run_rubocop_auto_correct
       run 'rubocop --auto-correct'
     end

--- a/lib/voyage/app_builder.rb
+++ b/lib/voyage/app_builder.rb
@@ -766,7 +766,7 @@ RUBY
     end
 
     def add_auto_annotate_models_rake_task
-      template '../templates/auto_annotate_models.rake', 'lib/tasks/auto_annotate_models.rake', force: true
+      template '../templates/lib/tasks/auto_annotate_models.rake', 'lib/tasks/auto_annotate_models.rake', force: true
     end
 
     def add_favicon
@@ -834,6 +834,9 @@ RUBY
       bundle_command 'exec rails generate erd:install'
 
       template '../templates/erdconfig.erb', '.erdconfig', force: true
+
+      # Configure post-migration and -rollback hooks
+      template '../templates/lib/tasks/post_migrate_hooks.rake', 'lib/tasks/post_migrate_hooks.rake', force: true
     end
 
     def run_rubocop_auto_correct

--- a/lib/voyage/generators/app_generator.rb
+++ b/lib/voyage/generators/app_generator.rb
@@ -52,6 +52,7 @@ module Suspenders
       invoke :configure_rvm_prepend_bin_to_path
       invoke :configure_sidekiq
       invoke :configure_letter_opener
+      invoke :configure_erd
       invoke :run_rubocop_auto_correct
       invoke :copy_env_to_example
       invoke :add_to_gitignore
@@ -167,6 +168,10 @@ module Suspenders
 
     def configure_letter_opener
       build :configure_letter_opener
+    end
+
+    def configure_erd
+      build :configure_erd
     end
 
     def setup_spring

--- a/lib/voyage/templates/erdconfig.erb
+++ b/lib/voyage/templates/erdconfig.erb
@@ -1,0 +1,13 @@
+attributes:
+  - content
+  - primary_key
+  - foreign_key
+  - inheritance
+filename: <%= app_name %>-erd
+exclude:
+  - ActiveRecord::DataMigration
+  - Delayed::Backend::ActiveRecord::Job
+  - PgSearch::Document
+  - Rpush::Client::ActiveRecord::App
+  - Rpush::Client::ActiveRecord::Apns::Feedback
+  - Rpush::Client::ActiveRecord::Notification

--- a/lib/voyage/templates/lib/tasks/auto_annotate_models.rake
+++ b/lib/voyage/templates/lib/tasks/auto_annotate_models.rake
@@ -32,15 +32,4 @@ if Rails.env.development?
     puts 'Annotating models...'
     system 'bundle exec annotate -p after -i'
   end
-
-  # Run annotate task after db:migrate and db:rollback tasks
-  Rake::Task['db:migrate'].enhance do
-    Rake::Task['annotate'].invoke
-    Rake::Task['db:test:prepare'].invoke
-  end
-
-  Rake::Task['db:rollback'].enhance do
-    Rake::Task['annotate'].invoke
-    Rake::Task['db:test:prepare'].invoke
-  end
 end

--- a/lib/voyage/templates/lib/tasks/post_migrate_hooks.rake
+++ b/lib/voyage/templates/lib/tasks/post_migrate_hooks.rake
@@ -1,0 +1,15 @@
+# :nocov:
+if Rails.env.development?
+  # Run annotate and erd tasks after db:migrate and db:rollback tasks
+  Rake::Task['db:migrate'].enhance do
+    Rake::Task['annotate'].invoke
+    Rake::Task['erd'].invoke
+    Rake::Task['db:test:prepare'].invoke
+  end
+
+  Rake::Task['db:rollback'].enhance do
+    Rake::Task['annotate'].invoke
+    Rake::Task['erd'].invoke
+    Rake::Task['db:test:prepare'].invoke
+  end
+end


### PR DESCRIPTION
* Adds a config file for the `erd` gem with some sane defaults
* Adds hooks to automatically generate the diagram after a migration or a rollback
* Moves our post-migrate/rollback hooks into a separate file for clarity.

This addresses issue #20 