### PR TITLE
Feature/add trix drag and drop

### DIFF
--- a/lib/voyage/app_builder.rb
+++ b/lib/voyage/app_builder.rb
@@ -654,10 +654,9 @@ module Suspenders
       generate 'administrate:assets:javascript'
       copy_file '../templates/trix_attachments.js', 'app/assets/javascripts/administrate/components/trix_attachments.js', force: true
 
-      inject_into_file 'app/abilities/users.rb', after: 'Canard::Abilities.for(:user) do' do <<-RUBY
+      inject_into_file 'app/abilities/users.rb', after: 'Canard::Abilities.for(:user) do' do <<-RUBY.gsub(/ {6}/, '')
 
-        can[:create], Image
-
+        can [:create], Image
       RUBY
       end
     end
@@ -690,7 +689,7 @@ module Suspenders
       # Remove association requirement for Trix uploading standalone Images
       gsub_file 'app/models/image.rb',
         'belongs_to :attachable, polymorphic: true',
-        'belongs_to :attachable, polymorphic: true, required: false',
+        'belongs_to :attachable, polymorphic: true, required: false'
 
       inject_into_file 'app/models/attachment.rb', after: 'class Attachment < ApplicationRecord', force: true do <<-RUBY
 
@@ -721,7 +720,7 @@ module Suspenders
 
       # Remove encrypted password field
       gsub_file 'app/dashboards/user_dashboard.rb',
-        ':encrypted_password',
+        ':encrypted_password,',
         ''
 
       inject_into_file 'app/dashboards/user_dashboard.rb', after: 'ATTRIBUTE_TYPES = {' do <<-RUBY.gsub(/^ {8}/, '    ')

--- a/lib/voyage/templates/images_controller.rb
+++ b/lib/voyage/templates/images_controller.rb
@@ -1,0 +1,28 @@
+class ImagesController < ApplicationController
+  load_and_authorize_resource
+  respond_to :json
+
+  def create
+    if image_params[:image].tempfile.closed?
+      image_params[:image].open()
+    end
+
+    @image = Image.new(image_params)
+
+    respond_to do |format|
+      if @image.save
+        # format.html { redirect_to @image, notice: 'Image was successfully created.' }
+        format.json { render json: { url: @image.image_url }, status: :ok }
+      else
+        # format.html { render :new }
+        format.json { render json: @image.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+
+  def image_params
+    params.require(:image).permit(:image)
+  end
+end

--- a/lib/voyage/templates/trix_attachments.js
+++ b/lib/voyage/templates/trix_attachments.js
@@ -1,0 +1,45 @@
+$(document).ready(function() {
+
+  Trix.config.attachments.preview.caption = {
+    name: false,
+    size: false
+  };
+
+  function uploadAttachment(attachment) {
+    var csrfToken = $('meta[name="csrf-token"]').attr('content');
+    var file = attachment.file;
+    var form = new FormData;
+    var endpoint = "/images";
+    form.append("Content-Type", file.type);
+    form.append("image[image]", file);
+
+    xhr = new XMLHttpRequest;
+    xhr.open("POST", endpoint, true);
+    xhr.setRequestHeader("X-CSRF-Token", csrfToken);
+
+    xhr.upload.onprogress = function(event) {
+      var progress = event.loaded / event.total * 100;
+      return attachment.setUploadProgress(progress);
+    };
+
+    xhr.onload = function() {
+      if (this.status >= 200 && this.status < 300) {
+        var data = JSON.parse(this.responseText);
+        return attachment.setAttributes({
+          url: data.url,
+          href: data.url
+        });
+      }
+    };
+
+    return xhr.send(form);
+  };
+
+  document.addEventListener("trix-attachment-add", function(event) {
+    var attachment = event.attachment;
+    if (attachment.file) {
+      return uploadAttachment(attachment);
+    }
+  });
+
+});


### PR DESCRIPTION
This sets up the necessary controller and Javascript hooks to be able to upload images by drag-and-drop into Trix.

- Made `:attachable` association on the `Image` model option, so that standalone resources can be created for uploaded images
- Removed the `:encrypted_password` attribute from the user dashboard, as this would allow updating the hashed/salted/... password and also wiped the user's password if the field was blank.

Fixes #37 