### PR TITLE
Add necessary route for drag-and-drop image uploading

### DIFF
--- a/lib/voyage/app_builder.rb
+++ b/lib/voyage/app_builder.rb
@@ -654,10 +654,16 @@ module Suspenders
       generate 'administrate:assets:javascript'
       copy_file '../templates/trix_attachments.js', 'app/assets/javascripts/administrate/components/trix_attachments.js', force: true
 
-      inject_into_file 'app/abilities/users.rb', after: 'Canard::Abilities.for(:user) do' do <<-RUBY.gsub(/ {6}/, '')
+      inject_into_file 'app/abilities/users.rb', after: 'Canard::Abilities.for(:user) do' do <<-RUBY.gsub(/^ {6}/, '')
 
         can [:create], Image
       RUBY
+      end
+
+      inject_into_file 'config/routes.rb', before: 'resources :users do' do <<-RUBY.gsub(/^ {6}/, '')
+        resources :images, only: [:create]
+
+        RUBY
       end
     end
 


### PR DESCRIPTION
In setting up the Trix drag-and-drop, I neglected to properly setup the route for POSTing new image resources. This PR fixes that and gets it fully functional in a new build.