### PR TITLE
Fix Administrate sidebar customizations

### DIFF
--- a/lib/voyage/app_builder.rb
+++ b/lib/voyage/app_builder.rb
@@ -637,6 +637,7 @@ module Suspenders
       generate 'administrate:views:edit'
 
       replace_in_file 'app/views/admin/application/_form.html.erb', 'form_for', "simple_form_for"
+      copy_file '../templates/views/admin/application/_navigation.html.erb', 'app/views/admin/application/_navigation.html.erb', force: true
 
       inject_into_file 'config/initializers/simple_form.rb', after: 'SimpleForm.setup do |config|' do <<-RUBY
 

--- a/lib/voyage/templates/views/admin/application/_navigation.html.erb
+++ b/lib/voyage/templates/views/admin/application/_navigation.html.erb
@@ -1,0 +1,20 @@
+<%#
+# Navigation
+
+This partial is used to display the navigation in Administrate.
+By default, the navigation contains navigation links
+for all resources in the admin dashboard,
+as defined by the routes in the `admin/` namespace
+%>
+
+<nav class="navigation" role="navigation">
+  <%# Administrate::Namespace.new(namespace).resources.each do |resource| %>
+
+  <% resources_for_sidebar_nav.each do |resource| %>
+    <%= link_to(
+      display_resource_name(resource),
+      [namespace, resource.path],
+      class: "navigation__link navigation__link--#{nav_link_state(resource)}"
+    ) %>
+  <% end %>
+</nav>


### PR DESCRIPTION
In spinning up the Festival app, Jason discovered that Voyage wasn't including the customized sidebar for hiding resources in Administrate. This was missed in an earlier PR of mine for setting up Administrate, and is fixed by adding this template file in.