### PR TITLE
Fix images :create route so it is only added once

### DIFF
--- a/lib/voyage/app_builder.rb
+++ b/lib/voyage/app_builder.rb
@@ -682,10 +682,10 @@ module Suspenders
       RUBY
       end
 
-      inject_into_file 'config/routes.rb', before: 'resources :users do' do <<-RUBY.gsub(/^ {6}/, '')
-        resources :images, only: [:create]
+      inject_into_file 'config/routes.rb', before: 'namespace :admin do' do <<-RUBY
+resources :images, only: [:create]
 
-        RUBY
+    RUBY
       end
     end
 


### PR DESCRIPTION
Previously, Voyage would add the create routes for the Image resource twice: once at the top-level and then once later within the admin namespace. This resolves the issue so it is only added once.

Resolves #66